### PR TITLE
Fix .org link in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -337,4 +337,4 @@ be included into your classes.
 
 * Who's responsible
 
-  Naught is by [[http://devblog.avdi.org][Avdi Grimm]].
+  Naught is by [[http://devblog.avdi.org/][Avdi Grimm]].


### PR DESCRIPTION
Org the markup language seems to treat URLs strangely, and specifically `.org` links to another "org" file, meaning that this link previously went to `http://devblog.avdi.html`.
