### PR TITLE
Do not ship with executables from bin/

### DIFF
--- a/naught.gemspec
+++ b/naught.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Otherwise you could overwrite people's `rspec`, `pry`, etc.
