### PR TITLE
Remove the project .rspec file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,0 @@
--fs --color --order rand


### PR DESCRIPTION
Since other rspec users often have their own preferences regarding rspec output, this is better suited to a `~/.rspec` file which allows everyone to have their own style while still running the same tests.
