### PR TITLE
Let the builder make its own decisions

### DIFF
--- a/lib/naught.rb
+++ b/lib/naught.rb
@@ -6,9 +6,6 @@ module Naught
   def self.build(&customization_block)
     builder = NullClassBuilder.new
     builder.customize(&customization_block)
-    unless builder.interface_defined?
-      builder.respond_to_any_message
-    end
     builder.generate_class
   end
   module NullObjectTag

--- a/lib/naught/null_class_builder.rb
+++ b/lib/naught/null_class_builder.rb
@@ -74,6 +74,7 @@ module Naught
     end
 
     def generate_class
+      respond_to_any_message unless interface_defined?
       generation_mod    = Module.new
       customization_mod = customization_module # get a local binding
       builder           = self


### PR DESCRIPTION
Instead of asking for information about the builder and then making a decision, let the builder handle that decision itself when generating the null object.
