### PR TITLE
Move implicit conversions to separated Command.

### DIFF
--- a/lib/naught.rb
+++ b/lib/naught.rb
@@ -1,6 +1,6 @@
 require "naught/version"
 require 'naught/null_class_builder'
-require 'naught/null_class_builder/commands/define_explicit_conversions'
+require 'naught/null_class_builder/commands'
 
 module Naught
   def self.build(&customization_block)

--- a/lib/naught/null_class_builder.rb
+++ b/lib/naught/null_class_builder.rb
@@ -116,14 +116,6 @@ module Naught
     #
     # See also the contents of lib/naught/null_class_builder/commands
     ############################################################################
-    def define_implicit_conversions
-      defer do |subject|
-        subject.module_eval do
-          def to_ary; []; end
-          def to_str; ''; end
-        end
-      end
-    end
 
     def black_hole
       @stub_strategy = :stub_method_returning_self

--- a/lib/naught/null_class_builder/commands.rb
+++ b/lib/naught/null_class_builder/commands.rb
@@ -1,0 +1,2 @@
+require 'naught/null_class_builder/commands/define_explicit_conversions'
+require 'naught/null_class_builder/commands/define_implicit_conversions'

--- a/lib/naught/null_class_builder/commands/base.rb
+++ b/lib/naught/null_class_builder/commands/base.rb
@@ -1,0 +1,19 @@
+module Naught
+  class NullClassBuilder
+    module Commands
+      class Base
+        def initialize(builder)
+          @builder = builder
+        end
+
+        def call
+          raise "Method #call should be overriden in child classes"
+        end
+
+        def defer(&block)
+          @builder.defer(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/naught/null_class_builder/commands/define_explicit_conversions.rb
+++ b/lib/naught/null_class_builder/commands/define_explicit_conversions.rb
@@ -1,11 +1,9 @@
+require 'naught/null_class_builder/commands/base'
 
 module Naught
   class NullClassBuilder
     module Commands
-      class DefineExplicitConversions
-        def initialize(builder)
-          @builder = builder
-        end
+      class DefineExplicitConversions < ::Naught::NullClassBuilder::Commands::Base
 
         def call
           defer do |subject|
@@ -21,9 +19,6 @@ module Naught
           end
         end
 
-        def defer(&block)
-          @builder.defer(&block)
-        end
       end
     end
   end

--- a/lib/naught/null_class_builder/commands/define_implicit_conversions.rb
+++ b/lib/naught/null_class_builder/commands/define_implicit_conversions.rb
@@ -1,0 +1,20 @@
+require 'naught/null_class_builder/commands/base'
+
+module Naught
+  class NullClassBuilder
+    module Commands
+      class DefineImplicitConversions < ::Naught::NullClassBuilder::Commands::Base
+
+        def call
+          defer do |subject|
+            subject.module_eval do
+              def to_ary; []; end
+              def to_str; ''; end
+            end
+          end
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Added `Base` command (for preventing code duplication)
