### PR TITLE
WIP: Use Object as default base class

### DIFF
--- a/lib/naught/null_class_builder.rb
+++ b/lib/naught/null_class_builder.rb
@@ -10,7 +10,7 @@ module Naught
 
     def initialize
       @interface_defined = false
-      @base_class        = BasicObject
+      @base_class        = Object
       @inspect_proc      = ->{ "<null>" }
       @stub_strategy     = :stub_method_returning_nil
       define_basic_methods

--- a/spec/base_object_spec.rb
+++ b/spec/base_object_spec.rb
@@ -23,7 +23,7 @@ describe 'null object with a custom base class' do
     Naught.build do |b|
       default_base_class = b.base_class
     end
-    expect(default_base_class).to eq(BasicObject)
+    expect(default_base_class).to eq(Object)
   end
 
   describe 'singleton null object' do


### PR DESCRIPTION
Trying to do https://github.com/avdi/naught/issues/5

Fails since `Object#to_s` is defined, along with some other methods.

Why would `Object` make more sense in the first place?
