### PR TITLE
Using double to create a stub to remove depreaction warning on specs

### DIFF
--- a/spec/naught/null_object_builder_spec.rb
+++ b/spec/naught/null_object_builder_spec.rb
@@ -15,7 +15,7 @@ module Naught
     end
 
     it 'translates method calls into command invocations including arguments' do
-      test_command = stub
+      test_command = double
       NullClassBuilder::Commands::TestCommand.should_receive(:new).
         with(builder, "foo", 42).
         and_return(test_command)


### PR DESCRIPTION
Using double instead of stub, since stub is deprecated in rspec-mocks since this commit got merged: https://github.com/rspec/rspec-mocks/commit/843a40f4483be9888ba03a415468be99182f0b4a
