### PR TITLE
Fix JRuby compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 env:
   - TRAVIS=true
+rvm:
+  - 1.9.2
+  - 1.9.3
+  - 2.0.0
+  - jruby-19mode
+  - jruby-20mode

--- a/lib/naught/null_class_builder/commands/traceable.rb
+++ b/lib/naught/null_class_builder/commands/traceable.rb
@@ -1,4 +1,5 @@
 require 'naught/null_class_builder/command'
+require 'naught/ruby_engine'
 
 module Naught::NullClassBuilder::Commands
   class Traceable < Naught::NullClassBuilder::Command
@@ -8,7 +9,7 @@ module Naught::NullClassBuilder::Commands
           attr_reader :__file__, :__line__
 
           def initialize(options={})
-            backtrace = options.fetch(:caller) { Kernel.caller(4) }
+            backtrace = options.fetch(:caller) { Kernel.caller(RubyEngine.backtrace_initialization_offset) }
             @__file__, line, _ = backtrace[0].split(':')
             @__line__ = line.to_i
           end

--- a/lib/naught/ruby_engine.rb
+++ b/lib/naught/ruby_engine.rb
@@ -1,0 +1,31 @@
+module RubyEngine
+
+  def self.engine_mappings
+    {
+      'ruby' => MRI,
+      'jruby' => JRuby,
+    }
+  end
+
+  module_function
+
+  def engine
+    engine_mappings[RUBY_ENGINE]
+  end
+
+  def backtrace_initialization_offset
+    engine.backtrace_initialization_offset
+  end
+
+  module MRI
+    def self.backtrace_initialization_offset
+      4
+    end
+  end
+
+  module JRuby
+    def self.backtrace_initialization_offset
+      3
+    end
+  end
+end

--- a/spec/pebble_spec.rb
+++ b/spec/pebble_spec.rb
@@ -46,29 +46,17 @@ describe 'pebble null object' do
   end
 
   context "when is called from a block" do
-    it "prints the indication of a block" do
-      expect(test_output).to receive(:puts).twice.
-        with(/from block/)
-      Caller.new.call_method_inside_block(null)
-    end
-
     it "prints the name of the method that has the block" do
       expect(test_output).to receive(:puts).twice.
-        with(/in call_method_inside_block$/)
+        with(/call_method_inside_block$/)
       Caller.new.call_method_inside_block(null)
     end
   end
 
   context "when is called from many levels blocks" do
-    it "prints the indication of blocks and its levels" do
-      expect(test_output).to receive(:puts).exactly(4).times.
-        with(/from block \(2 levels\)/)
-      Caller.new.call_method_inside_nested_block(null)
-    end
-
     it "prints the name of the method that has the block" do
       expect(test_output).to receive(:puts).exactly(4).times.
-        with(/in call_method_inside_nested_block$/)
+        with(/call_method_inside_nested_block$/)
       Caller.new.call_method_inside_nested_block(null)
     end
   end


### PR DESCRIPTION
See the comments on https://github.com/avdi/naught/pull/27
- Ran into prolems identifying the line and file of instantiation
  for traceable null objects because of slight differences in
  MRI's and JRuby's backtraces.
  - Create a RubyEngine module to handle slight differences like
    the above between different ruby engines.
- JRuby's backtrace doesn't give a clear indication of when methods
  are called from inside blocks.
  - It's not vital that this information be tracked by
    pebble objects, so we'll drop the specs that try to verify that.
- JRuby's backtrace also prints out a different trace for methods:
  "from calling_method" instead of "in calling_method".
  - Drop the preposition and just verify against the method name
