### PR TITLE
Change the syntax of the first ruby code example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,9 +21,9 @@ Here's a method that's not very sure of itself.
 ```ruby
 class Geordi
   def make_it_so(logger=nil)
-    logger && logger.info "Reversing the flux phase capacitance!"
-    logger && logger.info "Bounding a tachyon particle beam off of Data's cat!"
-    logger && logger.warn "Warning, bogon levels are rising!"
+    logger && logger.info("Reversing the flux phase capacitance!")
+    logger && logger.info("Bounding a tachyon particle beam off of Data's cat!")
+    logger && logger.warn("Warning, bogon levels are rising!")
   end
 end
 ```


### PR DESCRIPTION
Not very important but the method which is not very sure of itself produces syntax error:

``` ruby
test.rb:3: syntax error, unexpected tSTRING_BEG, expecting keyword_end
    logger && logger.info "Reversing the flux phase capacitance!"
                           ^
test.rb:4: syntax error, unexpected tSTRING_BEG, expecting keyword_end
    logger && logger.info "Bounding a tachyon particle b..."
                           ^
test.rb:5: syntax error, unexpected tSTRING_BEG, expecting keyword_end
    logger && logger.warn "Warning, bogon levels are rising!"
```
