### PR TITLE
Update README with version information

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,9 @@
 [![Coverage Status](https://coveralls.io/repos/avdi/naught/badge.png?branch=master)](https://coveralls.io/r/avdi/naught?branch=master)
 [![Gem Version](https://badge.fury.io/rb/naught.png)](http://badge.fury.io/rb/naught)
 
+## Version
+You are reading the documentation for the next release of Naught (0.0.3). The current stable release is [0.0.2](https://github.com/avdi/naught/blob/v0.0.2/README.org)
+
 A quick intro to Naught
 -------------------------
 


### PR DESCRIPTION
Add current expected version and link to current stable release.

This is almost verbatim from [grape](https://github.com/intridea/grape/) and I find it a huge benefit for a simple change. It addresses issues like #39 where someone is viewing documentation for master and trying to use the features on a release version.

It does have the drawback that the release process needs to take it into account.
