### PR TITLE
Add __callstack__ to return methods calls

### DIFF
--- a/lib/naught/null_class_builder.rb
+++ b/lib/naught/null_class_builder.rb
@@ -164,7 +164,7 @@ module Naught
     def stub_method_returning_self(subject, name)
       subject.module_eval do
         define_method('__callstack__') { @callstack ||=[]; @callstack}
-        define_method(name) {|*args| __callstack__.push(args.first); self }
+        define_method(name) {|*args| __callstack__.push([args[0], args[1]]); self }
       end
     end
 

--- a/spec/blackhole_spec.rb
+++ b/spec/blackhole_spec.rb
@@ -15,7 +15,11 @@ describe 'black hole null object' do
   end
   
   it 'returns callstack from arbitray method calls' do
-    expect(null.down.the.rabbit.hole.__callstack__).to eq [:down, :the, :rabbit, :hole]
+    expect(null.down.the.rabbit.hole.__callstack__).to eq [[:down, nil], [:the, nil], [:rabbit, nil], [:hole, nil]]
+  end
+
+  it 'returns callstack from array element calls' do
+    expect(null.down['bats'].__callstack__).to eq([[:down, nil], [:[],'bats']])
   end
 
 end


### PR DESCRIPTION
I wanted to be able to do something like this

``` ruby
Locals = Naught.build do |c|
  c.black_hole
  def to_s
    __callstack__.join('.')
  end
end
```
