### PR TITLE
Document predicates_return

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -107,7 +107,7 @@ null.foo.bar.baz                   # => <null>
 null << "hello" << "world"         # => <null>
 ```
 
-### What's that "config" thing?
+#### What's that "config" thing?
 
 That's what you use to customize the generated class to your
 liking. Internally, Naught uses the [Builder


### PR DESCRIPTION
I had no idea that the `PredicatesReturn` command existed until I started reading the source code. It seems like a pretty nifty configuration option, so I added it to the `README`, along with all the other commands.

I’ve made my best attempt to write this documentation using the same tone and personality in which the `README` is so delightfully written. Of course, your authentic voice is certainly better than my impersonation, so feel free to rip this pull request to shreds and reword it. At the very least, you should be able to use my code examples. I figured this was better than opening an issue with the title “Document predicates_return”.

As for its position in the `README`, I think it dovetails nicely with the section on overriding methods. I even added an example to that section, showing how to override a predicate method.
