### PR TITLE
Add docs badge to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,7 @@
 [![Code Climate](https://codeclimate.com/github/avdi/naught.png)](https://codeclimate.com/github/avdi/naught)
 [![Coverage Status](https://coveralls.io/repos/avdi/naught/badge.png?branch=master)](https://coveralls.io/r/avdi/naught?branch=master)
 [![Gem Version](https://badge.fury.io/rb/naught.png)](http://badge.fury.io/rb/naught)
+[![Inline docs](http://inch-pages.github.io/github/avdi/naught.png)](http://inch-pages.github.io/github/avdi/naught)
 
 A quick intro to Naught
 -------------------------


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/avdi/naught.png)

Your status page for this project is http://inch-pages.github.io/github/avdi/naught

Thanks for giving this a shot!

P.S. Naught seems really cool. I only knew this "blackhole" approach by flori: http://rubylution.ping.de/articles/2006/05/03/null-object-pattern
P.P.S. I really like your "contribution guidelines" :neckbeard: 
