### PR TITLE
Add "Libraries Using Naught" to Readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -458,3 +458,8 @@ Further reading
 -   [Null Objects and
     Falsiness](http://devblog.avdi.org/2011/05/30/null-objects-and-falsiness/),
     by Avdi Grimm
+
+Libraries Using Naught
+-----------------------
+
+-   [ActiveNull](https://github.com/Originate/active_null) Null Model support for ActiveRecord.


### PR DESCRIPTION
Added a section at the end of the Readme to highlight libraries making use of Naught. Others are encouraged to add to this section through additional PRs.
